### PR TITLE
Fixed add project button in profile page

### DIFF
--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -48,12 +48,13 @@ class Profile extends Component {
             <MessagesAndFriends />
             <br></br>
             <br></br>
-            <Button loading>
-              <label>Add Project</label>
             <Link to='/createproject'>
-              <Icon name='add'/>
-            </Link>
+            <Button color='blue'>
+              <label>
+              <Icon name='add'/> Add Project
+              </label>
             </Button>
+            </Link>
           </Grid.Column>
           </Grid.Row>
 


### PR DESCRIPTION
Fixed add project button in profile page. The icon was linked, not the button.